### PR TITLE
Implement Phase 3: schemas/ package with data contracts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["topology*", "utilities*"]
+include = ["topology*", "utilities*", "schemas*"]
 
 [project]
 name = "skyknit"
@@ -22,7 +22,7 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["topology/tests", "utilities/tests"]
+testpaths = ["topology/tests", "utilities/tests", "schemas/tests"]
 
 [tool.ruff]
 line-length = 100
@@ -33,7 +33,7 @@ select = ["E", "W", "F", "I"]
 ignore = ["E501"]
 
 [tool.ruff.lint.isort]
-known-first-party = ["topology", "utilities"]
+known-first-party = ["topology", "utilities", "schemas"]
 
 [tool.mypy]
 python_version = "3.14"
@@ -46,4 +46,8 @@ disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = "utilities.tests.*"
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = "schemas.tests.*"
 disallow_untyped_defs = false

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,0 +1,40 @@
+"""
+Schema definitions for Skyknit 2.0 data contracts.
+
+Provides the shared data structures (IR operations, shape manifest, constraint
+object, proportion spec) that flow between architectural modules.
+"""
+
+from .constraint import ConstraintObject, StitchMotif, YarnSpec
+from .ir import (
+    ComponentIR,
+    Operation,
+    OpType,
+    make_bind_off,
+    make_cast_on,
+    make_work_even,
+)
+from .manifest import ComponentSpec, Handedness, ShapeManifest, ShapeType
+from .proportion import PrecisionPreference, ProportionSpec
+
+__all__ = [
+    # proportion
+    "PrecisionPreference",
+    "ProportionSpec",
+    # constraint
+    "StitchMotif",
+    "YarnSpec",
+    "ConstraintObject",
+    # manifest
+    "ShapeType",
+    "Handedness",
+    "ComponentSpec",
+    "ShapeManifest",
+    # ir
+    "OpType",
+    "Operation",
+    "ComponentIR",
+    "make_cast_on",
+    "make_work_even",
+    "make_bind_off",
+]

--- a/schemas/constraint.py
+++ b/schemas/constraint.py
@@ -1,0 +1,71 @@
+"""
+Constraint object schema: knitting constraints flowing into Stitch Fillers.
+
+The ConstraintObject bundles all knitting-physics inputs needed to convert
+physical dimensions into valid stitch counts: gauge, stitch motif, hard
+divisibility constraints, yarn metadata, and physical tolerance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from utilities.types import Gauge
+
+
+@dataclass(frozen=True)
+class StitchMotif:
+    """
+    A repeating stitch pattern with horizontal and vertical repeat counts.
+
+    Attributes:
+        name: Human-readable name for the motif (e.g. "2x2 ribbing").
+        stitch_repeat: Number of stitches in one horizontal repeat.
+        row_repeat: Number of rows in one vertical repeat.
+    """
+
+    name: str
+    stitch_repeat: int
+    row_repeat: int
+
+
+@dataclass(frozen=True)
+class YarnSpec:
+    """
+    Yarn specification metadata.
+
+    Attributes:
+        weight: Yarn weight category (e.g. "worsted", "DK").
+        fiber: Fiber content description (e.g. "100% merino wool").
+        needle_size_mm: Recommended needle diameter in mm.
+    """
+
+    weight: str
+    fiber: str
+    needle_size_mm: float
+
+
+@dataclass(frozen=True)
+class ConstraintObject:
+    """
+    Complete set of knitting constraints for a single component.
+
+    Bundles gauge, stitch motif, hard divisibility requirements, yarn
+    metadata, and physical tolerance. Passed into Stitch Fillers and the
+    Algebraic Checker.
+
+    ``gauge`` is imported from ``utilities`` — not a duplicate type.
+
+    Attributes:
+        gauge: Stitch and row density (from utilities.Gauge).
+        stitch_motif: Repeating stitch pattern for this component.
+        hard_constraints: Additional divisors the final stitch count must satisfy.
+        yarn_spec: Yarn weight, fiber, and needle size.
+        physical_tolerance_mm: Allowed physical deviation in mm.
+    """
+
+    gauge: Gauge
+    stitch_motif: StitchMotif
+    hard_constraints: tuple[int, ...]
+    yarn_spec: YarnSpec
+    physical_tolerance_mm: float

--- a/schemas/ir.py
+++ b/schemas/ir.py
@@ -1,0 +1,111 @@
+"""
+Intermediate Representation (IR) schema for knitting operations.
+
+The IR is the parameterized, component-level representation of knitting
+instructions. Operations are high-level (e.g. WORK_EVEN for N rows) — not
+flattened row-by-row. The Writer translates IR into pattern prose.
+
+ComponentIR is the unit of exchange between Stitch Fillers, the Algebraic
+Checker, and the Writer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from schemas.manifest import Handedness
+
+
+class OpType(str, Enum):
+    """Parameterized knitting operation types."""
+
+    CAST_ON = "CAST_ON"
+    INCREASE_SECTION = "INCREASE_SECTION"
+    WORK_EVEN = "WORK_EVEN"
+    DECREASE_SECTION = "DECREASE_SECTION"
+    SEPARATE = "SEPARATE"
+    TAPER = "TAPER"
+    BIND_OFF = "BIND_OFF"
+    HOLD = "HOLD"
+    PICKUP_STITCHES = "PICKUP_STITCHES"
+
+
+@dataclass(frozen=True)
+class Operation:
+    """
+    A single parameterized knitting operation within a component.
+
+    Attributes:
+        op_type: The type of operation.
+        parameters: Operation-specific parameters (e.g. shaping rates, pickup ratios).
+        row_count: Number of rows consumed by this operation, or None if N/A.
+        stitch_count_after: Live stitch count after this operation, or None if unchanged.
+        notes: Human-readable annotation for debugging or Writer hints.
+    """
+
+    op_type: OpType
+    parameters: dict[str, Any]
+    row_count: int | None
+    stitch_count_after: int | None
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class ComponentIR:
+    """
+    Complete IR for a single named component.
+
+    Operations are ordered from first to last worked. The Algebraic Checker
+    simulates this sequence to verify stitch counts are consistent.
+
+    Attributes:
+        component_name: Must match a ``ComponentSpec.name`` in the manifest.
+        handedness: LEFT, RIGHT, or NONE — propagated from ComponentSpec.
+        operations: Ordered sequence of parameterized operations.
+        starting_stitch_count: Live count before the first operation.
+        ending_stitch_count: Expected live count after the last operation.
+    """
+
+    component_name: str
+    handedness: Handedness
+    operations: tuple[Operation, ...]
+    starting_stitch_count: int
+    ending_stitch_count: int
+
+
+# Convenience factory functions for the most common single-op components.
+
+
+def make_cast_on(count: int, notes: str = "") -> Operation:
+    """Create a CAST_ON operation for ``count`` stitches."""
+    return Operation(
+        op_type=OpType.CAST_ON,
+        parameters={"count": count},
+        row_count=None,
+        stitch_count_after=count,
+        notes=notes,
+    )
+
+
+def make_work_even(row_count: int, stitch_count: int, notes: str = "") -> Operation:
+    """Create a WORK_EVEN operation spanning ``row_count`` rows."""
+    return Operation(
+        op_type=OpType.WORK_EVEN,
+        parameters={},
+        row_count=row_count,
+        stitch_count_after=stitch_count,
+        notes=notes,
+    )
+
+
+def make_bind_off(count: int, notes: str = "") -> Operation:
+    """Create a BIND_OFF operation consuming ``count`` stitches."""
+    return Operation(
+        op_type=OpType.BIND_OFF,
+        parameters={"count": count},
+        row_count=None,
+        stitch_count_after=0,
+        notes=notes,
+    )

--- a/schemas/manifest.py
+++ b/schemas/manifest.py
@@ -1,0 +1,68 @@
+"""
+Shape manifest schema: component specifications and join topology.
+
+ComponentSpec describes a single named shape with physical dimensions and
+edge references. ShapeManifest is the complete structural description of a
+sweater: all components and all joins connecting their edges.
+
+Edge and Join objects are reused from topology — schemas does not redefine them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from topology.types import Edge, Join
+
+
+class ShapeType(str, Enum):
+    """Geometric primitive for a knitted component."""
+
+    CYLINDER = "CYLINDER"
+    TRAPEZOID = "TRAPEZOID"
+    RECTANGLE = "RECTANGLE"
+
+
+class Handedness(str, Enum):
+    """Directional orientation of a component (for mirrored pairs)."""
+
+    LEFT = "LEFT"
+    RIGHT = "RIGHT"
+    NONE = "NONE"
+
+
+@dataclass(frozen=True)
+class ComponentSpec:
+    """
+    Specification for a single named component of the sweater.
+
+    Attributes:
+        name: Unique component identifier (e.g. "body", "left_sleeve").
+        shape_type: Geometric primitive this component is based on.
+        dimensions: Physical dimensions in mm keyed by measurement name.
+        edges: Ordered tuple of typed edges bounding this component.
+        handedness: LEFT, RIGHT, or NONE for unpaired components.
+        instantiation_count: How many times this spec is instantiated (e.g. 2 for sleeves).
+    """
+
+    name: str
+    shape_type: ShapeType
+    dimensions: dict[str, float]
+    edges: tuple[Edge, ...]
+    handedness: Handedness
+    instantiation_count: int
+
+
+@dataclass(frozen=True)
+class ShapeManifest:
+    """
+    Complete structural topology of the sweater.
+
+    Attributes:
+        components: All component specs.
+        joins: All joins connecting component edges.
+    """
+
+    components: tuple[ComponentSpec, ...]
+    joins: tuple[Join, ...]

--- a/schemas/proportion.py
+++ b/schemas/proportion.py
@@ -1,0 +1,50 @@
+"""
+Proportion specification schema: dimensionless ratios for sweater component sizing.
+
+PrecisionPreference mirrors utilities.PrecisionLevel but lives in schemas to
+avoid a hard upward dependency from schemas onto utilities internals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+
+
+class PrecisionPreference(str, Enum):
+    """
+    Preferred tolerance precision for this proportion spec.
+
+    Maps directly to utilities.PrecisionLevel values:
+      HIGH   → 0.75 (tightest band)
+      MEDIUM → 1.0
+      LOW    → 1.5  (widest band)
+    """
+
+    HIGH = "HIGH"
+    MEDIUM = "MEDIUM"
+    LOW = "LOW"
+
+
+@dataclass(frozen=True)
+class ProportionSpec:
+    """
+    Dimensionless ratio specification for sweater components.
+
+    All values in ``ratios`` are pure ratios (no physical units).
+    Physical dimensions are computed downstream by multiplying against
+    body measurements.
+
+    Attributes:
+        ratios: Mapping of component/measurement names to dimensionless ratios.
+        precision: Preferred precision for tolerance calculations.
+    """
+
+    ratios: MappingProxyType[str, float]
+    precision: PrecisionPreference
+
+    def __post_init__(self) -> None:
+        # Ensure callers stored a MappingProxyType so ratios are immutable.
+        if not isinstance(self.ratios, MappingProxyType):
+            raise TypeError(f"ratios must be a MappingProxyType, got {type(self.ratios).__name__}")

--- a/schemas/tests/test_constraint.py
+++ b/schemas/tests/test_constraint.py
@@ -1,0 +1,89 @@
+"""Tests for schemas.constraint — ConstraintObject, StitchMotif, YarnSpec."""
+
+import pytest
+
+from schemas.constraint import ConstraintObject, StitchMotif, YarnSpec
+from utilities import Gauge
+
+
+@pytest.fixture
+def sample_gauge():
+    return Gauge(stitches_per_inch=5.0, rows_per_inch=7.0)
+
+
+@pytest.fixture
+def sample_motif():
+    return StitchMotif(name="2x2 ribbing", stitch_repeat=4, row_repeat=1)
+
+
+@pytest.fixture
+def sample_yarn():
+    return YarnSpec(weight="DK", fiber="100% merino wool", needle_size_mm=3.75)
+
+
+@pytest.fixture
+def sample_constraint(sample_gauge, sample_motif, sample_yarn):
+    return ConstraintObject(
+        gauge=sample_gauge,
+        stitch_motif=sample_motif,
+        hard_constraints=(4, 6),
+        yarn_spec=sample_yarn,
+        physical_tolerance_mm=5.08,
+    )
+
+
+class TestStitchMotif:
+    def test_construction(self):
+        motif = StitchMotif(name="stockinette", stitch_repeat=1, row_repeat=1)
+        assert motif.name == "stockinette"
+        assert motif.stitch_repeat == 1
+        assert motif.row_repeat == 1
+
+    def test_is_frozen(self, sample_motif):
+        with pytest.raises(Exception):
+            sample_motif.stitch_repeat = 8
+
+
+class TestYarnSpec:
+    def test_construction(self, sample_yarn):
+        assert sample_yarn.weight == "DK"
+        assert sample_yarn.fiber == "100% merino wool"
+        assert sample_yarn.needle_size_mm == 3.75
+
+    def test_is_frozen(self, sample_yarn):
+        with pytest.raises(Exception):
+            sample_yarn.weight = "worsted"
+
+
+class TestConstraintObject:
+    def test_all_fields_accessible(
+        self, sample_constraint, sample_gauge, sample_motif, sample_yarn
+    ):
+        assert sample_constraint.gauge == sample_gauge
+        assert sample_constraint.stitch_motif == sample_motif
+        assert sample_constraint.hard_constraints == (4, 6)
+        assert sample_constraint.yarn_spec == sample_yarn
+        assert sample_constraint.physical_tolerance_mm == 5.08
+
+    def test_is_frozen(self, sample_constraint):
+        with pytest.raises(Exception):
+            sample_constraint.physical_tolerance_mm = 10.0
+
+    def test_reuses_gauge_from_utilities(self, sample_constraint):
+        """Gauge must be utilities.Gauge — not a duplicate schema-local type."""
+        from utilities.types import Gauge as UtilGauge
+
+        assert isinstance(sample_constraint.gauge, UtilGauge)
+
+    def test_hard_constraints_is_tuple(self, sample_constraint):
+        assert isinstance(sample_constraint.hard_constraints, tuple)
+
+    def test_empty_hard_constraints(self, sample_gauge, sample_motif, sample_yarn):
+        obj = ConstraintObject(
+            gauge=sample_gauge,
+            stitch_motif=sample_motif,
+            hard_constraints=(),
+            yarn_spec=sample_yarn,
+            physical_tolerance_mm=3.0,
+        )
+        assert obj.hard_constraints == ()

--- a/schemas/tests/test_init.py
+++ b/schemas/tests/test_init.py
@@ -1,0 +1,104 @@
+"""Tests for schemas public API — all public names importable from schemas."""
+
+import schemas
+
+
+class TestPublicAPI:
+    def test_all_defined(self):
+        assert hasattr(schemas, "__all__")
+
+    def test_all_names_importable(self):
+        """Every name in __all__ is actually importable from the package."""
+        for name in schemas.__all__:
+            assert hasattr(schemas, name), f"{name!r} in __all__ but not importable"
+
+    def test_proportion_types_importable(self):
+        from types import MappingProxyType
+
+        from schemas import PrecisionPreference, ProportionSpec
+
+        spec = ProportionSpec(
+            ratios=MappingProxyType({"body_length": 0.6}),
+            precision=PrecisionPreference.MEDIUM,
+        )
+        assert spec.precision == PrecisionPreference.MEDIUM
+
+    def test_constraint_types_importable(self):
+        from schemas import ConstraintObject, StitchMotif, YarnSpec
+        from utilities import Gauge
+
+        motif = StitchMotif(name="stockinette", stitch_repeat=1, row_repeat=1)
+        assert motif.stitch_repeat == 1
+        yarn = YarnSpec(weight="DK", fiber="wool", needle_size_mm=3.75)
+        assert yarn.weight == "DK"
+        obj = ConstraintObject(
+            gauge=Gauge(stitches_per_inch=5.0, rows_per_inch=7.0),
+            stitch_motif=motif,
+            hard_constraints=(),
+            yarn_spec=yarn,
+            physical_tolerance_mm=5.08,
+        )
+        assert obj.physical_tolerance_mm == 5.08
+
+    def test_manifest_types_importable(self):
+        from schemas import ComponentSpec, Handedness, ShapeManifest, ShapeType
+        from topology.types import Edge, EdgeType
+
+        spec = ComponentSpec(
+            name="body",
+            shape_type=ShapeType.CYLINDER,
+            dimensions={"circumference_mm": 914.4},
+            edges=(Edge(name="top", edge_type=EdgeType.LIVE_STITCH),),
+            handedness=Handedness.NONE,
+            instantiation_count=1,
+        )
+        manifest = ShapeManifest(components=(spec,), joins=())
+        assert len(manifest.components) == 1
+
+    def test_ir_types_importable(self):
+        from schemas import ComponentIR, Handedness, Operation, OpType
+
+        op = Operation(
+            op_type=OpType.CAST_ON,
+            parameters={"count": 80},
+            row_count=None,
+            stitch_count_after=80,
+        )
+        ir = ComponentIR(
+            component_name="body",
+            handedness=Handedness.NONE,
+            operations=(op,),
+            starting_stitch_count=80,
+            ending_stitch_count=80,
+        )
+        assert ir.starting_stitch_count == 80
+
+    def test_ir_factories_importable(self):
+        from schemas import make_bind_off, make_cast_on, make_work_even
+
+        cast = make_cast_on(80)
+        even = make_work_even(row_count=10, stitch_count=80)
+        bind = make_bind_off(80)
+        assert cast.op_type.value == "CAST_ON"
+        assert even.row_count == 10
+        assert bind.stitch_count_after == 0
+
+    def test_all_names_in_all(self):
+        expected = {
+            "PrecisionPreference",
+            "ProportionSpec",
+            "StitchMotif",
+            "YarnSpec",
+            "ConstraintObject",
+            "ShapeType",
+            "Handedness",
+            "ComponentSpec",
+            "ShapeManifest",
+            "OpType",
+            "Operation",
+            "ComponentIR",
+            "make_cast_on",
+            "make_work_even",
+            "make_bind_off",
+        }
+        assert expected.issubset(set(schemas.__all__))

--- a/schemas/tests/test_ir.py
+++ b/schemas/tests/test_ir.py
@@ -1,0 +1,150 @@
+"""Tests for schemas.ir — OpType, Operation, ComponentIR."""
+
+import pytest
+
+from schemas.ir import (
+    ComponentIR,
+    Operation,
+    OpType,
+    make_bind_off,
+    make_cast_on,
+    make_work_even,
+)
+from schemas.manifest import Handedness
+
+
+class TestOpType:
+    def test_all_members_exist(self):
+        expected = {
+            "CAST_ON",
+            "INCREASE_SECTION",
+            "WORK_EVEN",
+            "DECREASE_SECTION",
+            "SEPARATE",
+            "TAPER",
+            "BIND_OFF",
+            "HOLD",
+            "PICKUP_STITCHES",
+        }
+        assert {m.name for m in OpType} == expected
+
+    def test_is_string_enum(self):
+        assert isinstance(OpType.CAST_ON, str)
+
+
+class TestOperation:
+    def test_construction(self):
+        op = Operation(
+            op_type=OpType.WORK_EVEN,
+            parameters={"pattern": "stockinette"},
+            row_count=20,
+            stitch_count_after=80,
+            notes="main body section",
+        )
+        assert op.op_type == OpType.WORK_EVEN
+        assert op.parameters["pattern"] == "stockinette"
+        assert op.row_count == 20
+        assert op.stitch_count_after == 80
+
+    def test_is_frozen(self):
+        op = Operation(
+            op_type=OpType.CAST_ON,
+            parameters={"count": 100},
+            row_count=None,
+            stitch_count_after=100,
+        )
+        with pytest.raises(Exception):
+            op.row_count = 5  # type: ignore[misc]
+
+    def test_optional_fields_default_none(self):
+        op = Operation(
+            op_type=OpType.BIND_OFF,
+            parameters={},
+            row_count=None,
+            stitch_count_after=None,
+        )
+        assert op.row_count is None
+        assert op.stitch_count_after is None
+        assert op.notes == ""
+
+
+class TestComponentIR:
+    def _simple_stockinette_ir(self) -> ComponentIR:
+        """Minimal valid IR: CAST_ON → WORK_EVEN → BIND_OFF."""
+        cast_on = make_cast_on(80)
+        work_even = make_work_even(row_count=40, stitch_count=80)
+        bind_off = make_bind_off(80)
+        return ComponentIR(
+            component_name="body",
+            handedness=Handedness.NONE,
+            operations=(cast_on, work_even, bind_off),
+            starting_stitch_count=80,
+            ending_stitch_count=0,
+        )
+
+    def test_construction(self):
+        ir = self._simple_stockinette_ir()
+        assert ir.component_name == "body"
+        assert ir.handedness == Handedness.NONE
+        assert len(ir.operations) == 3
+
+    def test_is_frozen(self):
+        ir = self._simple_stockinette_ir()
+        with pytest.raises(Exception):
+            ir.component_name = "sleeve"  # type: ignore[misc]
+
+    def test_operations_are_parameterized_not_row_by_row(self):
+        """Operations should span multiple rows — not one op per row."""
+        ir = self._simple_stockinette_ir()
+        work_even_op = ir.operations[1]
+        assert work_even_op.op_type == OpType.WORK_EVEN
+        assert work_even_op.row_count == 40
+        assert len(ir.operations) == 3  # not 40 individual row ops
+
+    def test_cast_on_to_work_even_to_bind_off_sequence(self):
+        ir = self._simple_stockinette_ir()
+        assert ir.operations[0].op_type == OpType.CAST_ON
+        assert ir.operations[1].op_type == OpType.WORK_EVEN
+        assert ir.operations[2].op_type == OpType.BIND_OFF
+
+    def test_handedness_annotation_present(self):
+        cast_on = make_cast_on(60)
+        bind_off = make_bind_off(60)
+        ir = ComponentIR(
+            component_name="left_sleeve",
+            handedness=Handedness.LEFT,
+            operations=(cast_on, bind_off),
+            starting_stitch_count=60,
+            ending_stitch_count=0,
+        )
+        assert ir.handedness == Handedness.LEFT
+
+    def test_stitch_count_tracking(self):
+        ir = self._simple_stockinette_ir()
+        assert ir.starting_stitch_count == 80
+        assert ir.ending_stitch_count == 0
+
+    def test_operations_are_tuple(self):
+        ir = self._simple_stockinette_ir()
+        assert isinstance(ir.operations, tuple)
+
+
+class TestConvenienceFactories:
+    def test_make_cast_on(self):
+        op = make_cast_on(100)
+        assert op.op_type == OpType.CAST_ON
+        assert op.parameters["count"] == 100
+        assert op.stitch_count_after == 100
+        assert op.row_count is None
+
+    def test_make_work_even(self):
+        op = make_work_even(row_count=20, stitch_count=80)
+        assert op.op_type == OpType.WORK_EVEN
+        assert op.row_count == 20
+        assert op.stitch_count_after == 80
+
+    def test_make_bind_off(self):
+        op = make_bind_off(80)
+        assert op.op_type == OpType.BIND_OFF
+        assert op.parameters["count"] == 80
+        assert op.stitch_count_after == 0

--- a/schemas/tests/test_manifest.py
+++ b/schemas/tests/test_manifest.py
@@ -1,0 +1,137 @@
+"""Tests for schemas.manifest — ShapeManifest, ComponentSpec, ShapeType, Handedness."""
+
+import pytest
+
+from schemas.manifest import ComponentSpec, Handedness, ShapeManifest, ShapeType
+from topology.types import Edge, EdgeType, Join, JoinType
+
+
+@pytest.fixture
+def body_edges():
+    return (
+        Edge(name="top", edge_type=EdgeType.LIVE_STITCH, join_ref="yoke_body_join"),
+        Edge(name="bottom", edge_type=EdgeType.BOUND_OFF, join_ref=None),
+    )
+
+
+@pytest.fixture
+def body_spec(body_edges):
+    return ComponentSpec(
+        name="body",
+        shape_type=ShapeType.CYLINDER,
+        dimensions={"circumference_mm": 914.4, "depth_mm": 457.2},
+        edges=body_edges,
+        handedness=Handedness.NONE,
+        instantiation_count=1,
+    )
+
+
+@pytest.fixture
+def sleeve_spec():
+    return ComponentSpec(
+        name="sleeve",
+        shape_type=ShapeType.TRAPEZOID,
+        dimensions={
+            "top_circumference_mm": 457.2,
+            "bottom_circumference_mm": 304.8,
+            "depth_mm": 457.2,
+        },
+        edges=(
+            Edge(name="top", edge_type=EdgeType.LIVE_STITCH, join_ref="yoke_sleeve_join"),
+            Edge(name="bottom", edge_type=EdgeType.BOUND_OFF, join_ref=None),
+        ),
+        handedness=Handedness.LEFT,
+        instantiation_count=2,
+    )
+
+
+@pytest.fixture
+def sample_join():
+    return Join(
+        id="yoke_body_join",
+        join_type=JoinType.CONTINUATION,
+        edge_a_ref="yoke.bottom",
+        edge_b_ref="body.top",
+    )
+
+
+@pytest.fixture
+def sample_manifest(body_spec, sleeve_spec, sample_join):
+    return ShapeManifest(
+        components=(body_spec, sleeve_spec),
+        joins=(sample_join,),
+    )
+
+
+class TestShapeType:
+    def test_members_exist(self):
+        assert ShapeType.CYLINDER
+        assert ShapeType.TRAPEZOID
+        assert ShapeType.RECTANGLE
+
+    def test_is_string_enum(self):
+        assert isinstance(ShapeType.CYLINDER, str)
+
+
+class TestHandedness:
+    def test_members_exist(self):
+        assert Handedness.LEFT
+        assert Handedness.RIGHT
+        assert Handedness.NONE
+
+    def test_is_string_enum(self):
+        assert isinstance(Handedness.LEFT, str)
+
+
+class TestComponentSpec:
+    def test_construction(self, body_spec, body_edges):
+        assert body_spec.name == "body"
+        assert body_spec.shape_type == ShapeType.CYLINDER
+        assert body_spec.handedness == Handedness.NONE
+        assert body_spec.instantiation_count == 1
+        assert body_spec.edges == body_edges
+
+    def test_is_frozen(self, body_spec):
+        with pytest.raises(Exception):
+            body_spec.name = "torso"
+
+    def test_edges_reference_topology_edge_type(self, body_spec):
+        """Edge types must come from topology.EdgeType — not a local enum."""
+        for edge in body_spec.edges:
+            assert isinstance(edge.edge_type, EdgeType)
+
+    def test_dimensions_are_physical_mm(self, body_spec):
+        """Dimensions dict values are floats (mm)."""
+        for v in body_spec.dimensions.values():
+            assert isinstance(v, float)
+
+    def test_instantiation_count(self, sleeve_spec):
+        assert sleeve_spec.instantiation_count == 2
+
+
+class TestShapeManifest:
+    def test_construction(self, sample_manifest, body_spec, sleeve_spec, sample_join):
+        assert len(sample_manifest.components) == 2
+        assert sample_manifest.components[0] == body_spec
+        assert sample_manifest.components[1] == sleeve_spec
+        assert len(sample_manifest.joins) == 1
+        assert sample_manifest.joins[0] == sample_join
+
+    def test_is_frozen(self, sample_manifest):
+        with pytest.raises(Exception):
+            sample_manifest.components = ()
+
+    def test_joins_reference_topology_join_type(self, sample_manifest):
+        """Join types must come from topology.JoinType."""
+        for join in sample_manifest.joins:
+            assert isinstance(join.join_type, JoinType)
+
+    def test_joins_use_component_dot_edge_format(self, sample_join):
+        """edge_a_ref and edge_b_ref follow 'component.edge' naming convention."""
+        assert "." in sample_join.edge_a_ref
+        assert "." in sample_join.edge_b_ref
+
+    def test_components_edges_referenced_by_name(self, body_spec):
+        edge_names = [e.name for e in body_spec.edges]
+        assert "top" in edge_names
+        assert "bottom" in edge_names

--- a/schemas/tests/test_proportion.py
+++ b/schemas/tests/test_proportion.py
@@ -1,0 +1,66 @@
+"""Tests for schemas.proportion — ProportionSpec and PrecisionPreference."""
+
+from types import MappingProxyType
+
+import pytest
+
+from schemas.proportion import PrecisionPreference, ProportionSpec
+from utilities import PrecisionLevel
+
+
+class TestPrecisionPreference:
+    def test_members_exist(self):
+        assert PrecisionPreference.HIGH
+        assert PrecisionPreference.MEDIUM
+        assert PrecisionPreference.LOW
+
+    def test_maps_to_precision_level_values(self):
+        """PrecisionPreference names must align with utilities.PrecisionLevel names."""
+        for pref in PrecisionPreference:
+            assert pref.name in PrecisionLevel.__members__, (
+                f"PrecisionPreference.{pref.name} has no matching PrecisionLevel"
+            )
+
+    def test_is_string_enum(self):
+        assert isinstance(PrecisionPreference.HIGH, str)
+
+
+class TestProportionSpec:
+    def test_construction(self):
+        spec = ProportionSpec(
+            ratios=MappingProxyType({"body_length": 0.6, "sleeve_length": 0.55}),
+            precision=PrecisionPreference.MEDIUM,
+        )
+        assert spec.ratios["body_length"] == 0.6
+        assert spec.precision == PrecisionPreference.MEDIUM
+
+    def test_is_frozen(self):
+        spec = ProportionSpec(
+            ratios=MappingProxyType({"a": 1.0}),
+            precision=PrecisionPreference.HIGH,
+        )
+        with pytest.raises(Exception):
+            spec.precision = PrecisionPreference.LOW  # type: ignore[misc]
+
+    def test_ratios_are_dimensionless(self):
+        """Ratios should be plain floats — no unit attached."""
+        spec = ProportionSpec(
+            ratios=MappingProxyType({"yoke_depth": 0.25}),
+            precision=PrecisionPreference.LOW,
+        )
+        assert isinstance(spec.ratios["yoke_depth"], float)
+
+    def test_requires_mapping_proxy(self):
+        with pytest.raises(TypeError):
+            ProportionSpec(
+                ratios={"body_length": 0.6},  # type: ignore[arg-type]
+                precision=PrecisionPreference.MEDIUM,
+            )
+
+    def test_ratios_immutable(self):
+        spec = ProportionSpec(
+            ratios=MappingProxyType({"x": 1.0}),
+            precision=PrecisionPreference.MEDIUM,
+        )
+        with pytest.raises(TypeError):
+            spec.ratios["x"] = 2.0  # type: ignore[index]


### PR DESCRIPTION
Adds the schemas/ package providing all shared data structures that flow
between architectural modules (Stitch Fillers, Algebraic Checker, Writer):

- schemas/proportion.py  — PrecisionPreference enum, ProportionSpec dataclass
- schemas/constraint.py  — StitchMotif, YarnSpec, ConstraintObject dataclasses
- schemas/manifest.py    — ShapeType, Handedness enums; ComponentSpec and
                           ShapeManifest frozen dataclasses (reuses topology Edge/Join)
- schemas/ir.py          — OpType enum, Operation and ComponentIR frozen dataclasses,
                           make_cast_on/make_work_even/make_bind_off factories
- schemas/__init__.py    — full public API with __all__
- 54 new tests across 4 test modules (234 total, all passing)
- pyproject.toml updated: schemas added to packages, testpaths, isort first-party,
  and mypy overrides

https://claude.ai/code/session_0148KeA4t5zRdqHfr9fa2jXz