### PR TITLE
Implement Phase 11: LLM Writer (two-pass pattern enhancement)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,9 +21,9 @@ Scope is top-down sweater construction for hand knitting (v1); machine knitting 
 | Planner | Deterministic | ✅ Complete |
 | Fabric Module | Deterministic | ✅ Complete |
 | Orchestrator | Deterministic | ✅ Complete |
-| Writer (`TemplateWriter`) | Deterministic stub | ✅ Complete (LLM variant: future) |
+| Writer (`TemplateWriter` + `LLMWriter`) | Deterministic + LLM | 🔄 Phase 11 — active |
 | Design Module (`DeterministicDesignModule`) | Deterministic stub | ✅ Complete (LLM variant: future) |
-| **Parser** (`LLMPatternParser`) | **LLM** | 🔄 **Phase 10 — active** |
+| Parser (`LLMPatternParser`) | LLM | ✅ Complete |
 | Geometric Validator Phase 2 (mesh/viz) | Deterministic | ⏳ Deferred |
 
 ---
@@ -127,12 +127,17 @@ widened tolerance.
 - Single retry for filler-origin checker failures (widens tolerance × 1.5)
 - Raises `PipelineError(stage, detail)` on unrecoverable failure
 
-### Writer
-- **Type:** LLM (v1: deterministic `TemplateWriter`)
+### Writer *(Phase 11 — active)*
+- **Type:** LLM (`LLMWriter`) + deterministic fallback (`TemplateWriter`)
 - **In:** WriterInput (ShapeManifest + IRs + component order)
 - **Out:** WriterOutput (per-component sections + full_pattern string)
-- **v1 status:** Template-based prose from `writer/templates.py`; uses writer_dispatch.yaml
+- **`TemplateWriter`:** Template-based prose from `writer/templates.py`; uses writer_dispatch.yaml
   for join rendering mode (INLINE / INSTRUCTION / HEADER_NOTE)
+- **`LLMWriter`:** Two-pass design — TemplateWriter provides ground-truth prose (correct numbers),
+  Claude rewrites into richer, more idiomatic language via `write_knitting_pattern` tool.
+  Optional context (gauge, stitch_motif, yarn_spec) enables physical-measurement conversions.
+  Gracefully falls back to TemplateWriter output on any LLM failure.
+- Both satisfy the `PatternWriter` Protocol; inject via `generate_pattern(writer=...)`
 - Handedness drives left/right language in join instructions
 - Suppresses redundant CAST_ON when a PICKUP join instruction already emitted
 
@@ -306,8 +311,8 @@ skyknit.api          ──depends on──▶  skyknit.design, skyknit.fabric, 
 | 7 | Planner | ✅ |
 | 8 | Fabric Module + Orchestrator | ✅ |
 | 9 | Writer (template) + Design Module (stub) + API | ✅ |
-| **10** | **Parser (LLM) + Validator API** | 🔄 **active** |
-| 11 | Writer (LLM variant — richer prose) | ⏳ next |
+| 10 | Parser (LLM) + Validator API | ✅ |
+| **11** | **Writer (LLM variant — richer prose)** | 🔄 **active** |
 | 12 | Design Module (LLM variant — natural language intent) | ⏳ planned |
 | 13 | Geometric Validator Phase 2 (mesh + visualization) | ⏳ deferred |
 
@@ -319,7 +324,7 @@ skyknit.api          ──depends on──▶  skyknit.design, skyknit.fabric, 
 |---|---|---|
 | A | Hand-knit pipeline (build order 1–9) | ✅ Complete |
 | B | Made-to-measure as default interface | ✅ Substantially complete (`generate_pattern()`) |
-| C | Pattern validation tool (LLM Parser) | 🔄 Phase 10 |
+| C | Pattern validation tool (LLM Parser) | ✅ Complete |
 | D | FabricMode + machine knitting output (DAK format) | ⏳ Planned |
 | E | Yarn database + regional sourcing | ⏳ Planned |
 | F | Industrial machine formats (Stoll, Shima Seiki) | ⏳ Future |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,7 @@ disallow_untyped_defs = false
 [[tool.mypy.overrides]]
 module = "skyknit.parser.*"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "skyknit.writer.*"
+ignore_missing_imports = true

--- a/skyknit/api/generate.py
+++ b/skyknit/api/generate.py
@@ -17,7 +17,7 @@ from skyknit.orchestrator.pipeline import DeterministicOrchestrator, Orchestrato
 from skyknit.schemas.constraint import StitchMotif, YarnSpec
 from skyknit.schemas.proportion import PrecisionPreference
 from skyknit.utilities.types import Gauge
-from skyknit.writer.writer import TemplateWriter, WriterInput
+from skyknit.writer.writer import PatternWriter, TemplateWriter, WriterInput
 
 
 def generate_pattern(
@@ -28,6 +28,7 @@ def generate_pattern(
     yarn_spec: YarnSpec,
     ease_level: EaseLevel = EaseLevel.STANDARD,
     precision: PrecisionPreference = PrecisionPreference.MEDIUM,
+    writer: PatternWriter | None = None,
 ) -> str:
     """
     Generate a complete knitting pattern from body measurements and yarn specification.
@@ -50,6 +51,9 @@ def generate_pattern(
         Desired ease level; defaults to STANDARD.
     precision:
         Tolerance precision; defaults to MEDIUM.
+    writer:
+        Custom pattern writer; defaults to ``TemplateWriter()`` when ``None``.
+        Pass ``LLMWriter(...)`` for richer, LLM-enhanced prose.
 
     Returns
     -------
@@ -92,7 +96,8 @@ def generate_pattern(
         )
     )
 
-    writer_out = TemplateWriter().write(
+    _writer = writer if writer is not None else TemplateWriter()
+    writer_out = _writer.write(
         WriterInput(
             manifest=orch_out.manifest,
             irs=orch_out.irs,

--- a/skyknit/writer/llm_writer.py
+++ b/skyknit/writer/llm_writer.py
@@ -1,0 +1,135 @@
+"""
+LLMWriter — two-pass LLM-enhanced pattern writer.
+
+Pass 1 (deterministic): TemplateWriter generates correct, complete prose with
+exact stitch/row counts — the ground truth.
+
+Pass 2 (LLM): Claude receives the template prose and rewrites it into richer,
+more idiomatic knitting language via the write_knitting_pattern tool.  The LLM
+cannot change any number because the template prose already states them; any
+deviation would be a factual error the knitter could detect.
+
+On any failure (network error, no tool_use block, malformed JSON, missing section),
+write() returns the TemplateWriter output unchanged — the caller always gets a
+usable pattern.
+
+LLMWriter satisfies the PatternWriter Protocol and is a drop-in replacement for
+TemplateWriter in generate_pattern() or any other pipeline that accepts a writer.
+
+Requires the ``anthropic`` package (``uv add anthropic`` or
+``pip install skyknit[llm]``).  The import is deferred to ``__init__`` so the
+rest of the module is importable without the package installed.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+from skyknit.schemas.constraint import StitchMotif, YarnSpec
+from skyknit.utilities.types import Gauge
+from skyknit.writer.prompts import LLM_WRITER_TOOL_SCHEMA, SYSTEM_PROMPT
+from skyknit.writer.writer import TemplateWriter, WriterInput, WriterOutput
+
+
+def _build_context(
+    gauge: Gauge | None,
+    stitch_motif: StitchMotif | None,
+    yarn_spec: YarnSpec | None,
+) -> str:
+    """Build an optional context block for the LLM user message prefix.
+
+    Returns an empty string when all three arguments are None, so the caller
+    can test truthiness before prepending.
+    """
+    parts: list[str] = []
+    if gauge:
+        parts.append(
+            f"Gauge: {gauge.stitches_per_inch} stitches and {gauge.rows_per_inch} rows per inch."
+        )
+    if yarn_spec:
+        parts.append(
+            f"Yarn: {yarn_spec.weight} weight, {yarn_spec.fiber}, "
+            f"{yarn_spec.needle_size_mm} mm needles."
+        )
+    if stitch_motif:
+        parts.append(f"Stitch pattern: {stitch_motif.name}.")
+    return "\n".join(parts)
+
+
+class LLMWriter:
+    """
+    Two-pass LLM-enhanced pattern writer.
+
+    Satisfies the PatternWriter Protocol: accepts WriterInput, returns WriterOutput.
+
+    Optional context (gauge, stitch_motif, yarn_spec) set at construction time
+    enriches the LLM prompt so it can include physical-measurement conversions
+    and yarn-appropriate language.  All three are optional; omitting them still
+    produces richer prose — just without measurement approximations.
+
+    The Anthropic client reads ``ANTHROPIC_API_KEY`` from the environment.
+    """
+
+    def __init__(
+        self,
+        model: str = "claude-haiku-4-5-20251001",
+        max_tokens: int = 4096,
+        gauge: Gauge | None = None,
+        stitch_motif: StitchMotif | None = None,
+        yarn_spec: YarnSpec | None = None,
+    ) -> None:
+        try:
+            import anthropic
+
+            self._client = anthropic.Anthropic()
+        except ImportError as exc:
+            raise ImportError(
+                "Install the LLM extras for writer support: uv add anthropic"
+            ) from exc
+        self._model = model
+        self._max_tokens = max_tokens
+        self._gauge = gauge
+        self._stitch_motif = stitch_motif
+        self._yarn_spec = yarn_spec
+        self._template_writer = TemplateWriter()
+
+    def write(self, wi: WriterInput) -> WriterOutput:
+        """
+        Enhance template prose with LLM rewriting.
+
+        Falls back to TemplateWriter output with a UserWarning on any LLM failure.
+        """
+        template_out = self._template_writer.write(wi)
+
+        context = _build_context(self._gauge, self._stitch_motif, self._yarn_spec)
+        user_content = (
+            (context + "\n\n" + template_out.full_pattern) if context else template_out.full_pattern
+        )
+
+        try:
+            response = self._client.messages.create(
+                model=self._model,
+                max_tokens=self._max_tokens,
+                system=SYSTEM_PROMPT,
+                tools=[LLM_WRITER_TOOL_SCHEMA],
+                tool_choice={"type": "any"},
+                messages=[{"role": "user", "content": user_content}],
+            )
+            tool_block = next((b for b in response.content if b.type == "tool_use"), None)
+            if tool_block is None:
+                return template_out
+
+            raw_sections: dict[str, str] = tool_block.input["sections"]
+            # Fall back to template prose for any section the LLM omitted.
+            sections = {
+                name: raw_sections.get(name, template_out.sections[name])
+                for name in wi.component_order
+            }
+            full_pattern = "\n\n".join(sections[name] for name in wi.component_order)
+            return WriterOutput(sections=sections, full_pattern=full_pattern)
+        except Exception as exc:  # noqa: BLE001 — intentional broad catch for graceful fallback
+            warnings.warn(
+                f"LLMWriter failed, returning template prose: {exc}",
+                stacklevel=2,
+            )
+            return template_out

--- a/skyknit/writer/prompts.py
+++ b/skyknit/writer/prompts.py
@@ -1,0 +1,80 @@
+"""
+System prompt and tool schema for the LLM pattern writer.
+
+SYSTEM_PROMPT is the semantic complement of parser/prompts.py: where the parser
+extracts operation data from prose, the writer enhances template prose into richer,
+more idiomatic knitting language.
+
+LLM_WRITER_TOOL_SCHEMA defines the single Claude tool used for structured output.
+tool_choice={"type": "any"} in the API call forces Claude to call this tool,
+guaranteeing per-section JSON output rather than free-text prose.
+"""
+
+from __future__ import annotations
+
+SYSTEM_PROMPT = """You are a knitting pattern editor. You receive a machine-generated
+knitting pattern and rewrite it into richer, more natural knitting language.
+
+## Critical rules (never violate)
+
+1. Preserve ALL stitch counts, row counts, and numbers EXACTLY as given.
+   Never change, omit, or round any number.
+2. Preserve section headers exactly (e.g. "Body", "Left Sleeve") — do not rename,
+   reorder, or merge sections.
+3. Return one entry per section in the tool output. Every section in the input
+   must appear in the output. Use the exact snake_case component names as JSON
+   keys (e.g. ``"body"``, ``"left_sleeve"``), not the display-formatted headers.
+4. Do NOT add new operations that are not in the input (no new cast-ons, bind-offs,
+   or shaping steps that were not already present).
+
+## What to improve
+
+- Cast-on: specify method where natural ("Using a long-tail cast-on, cast on N sts.")
+- Work even: suggest measurement equivalent when gauge is provided, e.g.
+  "Continue in stockinette until piece measures approximately X\" / X cm (N rows)."
+- Shaping: use traditional decrease/increase notation, e.g.
+  "*K1, ssk, work to last 3 sts, k2tog, k1.* Repeat every Xth row N times."
+  rather than just "Decrease to N sts over R rows."
+- Pick-up: add directional cue, e.g.
+  "Beginning at the underarm, pick up and knit N sts evenly along the armhole edge."
+- Bind-off: suggest tension note where appropriate, e.g.
+  "Bind off all N sts loosely knitwise."
+- Section headers: keep as-is but may add a brief parenthetical note such as
+  "(make 2)" or the needle/yarn reminder if appropriate.
+
+## What NOT to change
+
+- Section names (keep exactly as provided)
+- Any number in the pattern
+- The sequence of operations within a section
+- Join instructions (PICKUP, SEAM, HELD_STITCH) — these are already well-formed
+
+## Context
+
+If a context block is provided at the start of the user message (Gauge, Yarn,
+Stitch pattern), use it to:
+- Calculate approximate physical measurements from row/stitch counts.
+- Tailor cast-on method and stitch pattern language to the stated yarn and motif.
+"""
+
+LLM_WRITER_TOOL_SCHEMA: dict = {
+    "name": "write_knitting_pattern",
+    "description": (
+        "Return enhanced prose sections for each garment component. "
+        "One entry per component name, preserving all numbers exactly."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "sections": {
+                "type": "object",
+                "description": (
+                    "Mapping of component_name → enhanced pattern prose. "
+                    "Every component from the input must appear as a key."
+                ),
+                "additionalProperties": {"type": "string"},
+            }
+        },
+        "required": ["sections"],
+    },
+}

--- a/tests/api/test_generate.py
+++ b/tests/api/test_generate.py
@@ -9,6 +9,7 @@ from skyknit.design.module import EaseLevel
 from skyknit.schemas.constraint import StitchMotif, YarnSpec
 from skyknit.schemas.proportion import PrecisionPreference
 from skyknit.utilities.types import Gauge
+from skyknit.writer.writer import WriterInput, WriterOutput
 
 # ── Shared fixtures ────────────────────────────────────────────────────────────
 
@@ -131,3 +132,40 @@ class TestEaseLevel:
         )
         # Patterns differ because stitch counts change with ease
         assert fitted != relaxed
+
+
+# ── Writer injection ───────────────────────────────────────────────────────────
+
+
+class _MarkerWriter:
+    """Deterministic stub that returns a fixed sentinel string."""
+
+    def write(self, wi: WriterInput) -> WriterOutput:
+        return WriterOutput(
+            sections={name: "MARKER" for name in wi.component_order},
+            full_pattern="MARKER",
+        )
+
+
+class TestWriterInjection:
+    def test_custom_writer_is_called(self):
+        result = generate_pattern(
+            "top-down-drop-shoulder-pullover",
+            _MEASUREMENTS_DROP,
+            _GAUGE,
+            _MOTIF,
+            _YARN,
+            writer=_MarkerWriter(),
+        )
+        assert result == "MARKER"
+
+    def test_none_writer_uses_template_writer(self):
+        result = generate_pattern(
+            "top-down-drop-shoulder-pullover",
+            _MEASUREMENTS_DROP,
+            _GAUGE,
+            _MOTIF,
+            _YARN,
+            writer=None,
+        )
+        assert "Cast on" in result

--- a/tests/writer/test_llm_writer.py
+++ b/tests/writer/test_llm_writer.py
@@ -1,0 +1,272 @@
+"""
+Tests for skyknit/writer/llm_writer.py — LLMWriter.
+
+Unit tests (CI-safe) mock the anthropic client via unittest.mock so no real
+API calls are made.  Integration tests require ANTHROPIC_API_KEY and are
+skipped in CI.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import MappingProxyType
+from unittest.mock import MagicMock
+
+import pytest
+
+import skyknit.planner.garments  # noqa: F401 — triggers garment registration
+from skyknit.fabric.module import FabricInput
+from skyknit.orchestrator.pipeline import DeterministicOrchestrator, OrchestratorInput
+from skyknit.planner.garments.registry import get
+from skyknit.schemas.constraint import StitchMotif, YarnSpec
+from skyknit.schemas.proportion import PrecisionPreference, ProportionSpec
+from skyknit.utilities.types import Gauge
+from skyknit.writer.writer import PatternWriter, WriterInput, WriterOutput
+
+# ── Shared fixtures ────────────────────────────────────────────────────────────
+
+_GAUGE = Gauge(stitches_per_inch=20.0, rows_per_inch=28.0)
+_MOTIF = StitchMotif(name="stockinette", stitch_repeat=1, row_repeat=1)
+_YARN = YarnSpec(weight="DK", fiber="wool", needle_size_mm=4.0)
+
+_PROPORTION = ProportionSpec(
+    ratios=MappingProxyType({"body_ease": 1.08, "sleeve_ease": 1.1, "wrist_ease": 1.05}),
+    precision=PrecisionPreference.MEDIUM,
+)
+_FABRIC = FabricInput(
+    component_names=(),
+    gauge=_GAUGE,
+    stitch_motif=_MOTIF,
+    yarn_spec=_YARN,
+    precision=PrecisionPreference.MEDIUM,
+)
+_MEASUREMENTS = {
+    "chest_circumference_mm": 914.4,
+    "body_length_mm": 457.2,
+    "sleeve_length_mm": 495.3,
+    "upper_arm_circumference_mm": 381.0,
+    "wrist_circumference_mm": 152.4,
+}
+
+
+def _drop_shoulder_writer_input() -> WriterInput:
+    oi = OrchestratorInput(
+        garment_spec=get("top-down-drop-shoulder-pullover"),
+        proportion_spec=_PROPORTION,
+        measurements=_MEASUREMENTS,
+        fabric_input=_FABRIC,
+    )
+    out = DeterministicOrchestrator().run(oi)
+    return WriterInput(manifest=out.manifest, irs=out.irs, component_order=out.component_order)
+
+
+def _make_mock_client(sections: dict[str, str]) -> MagicMock:
+    """Return a mock anthropic.Anthropic() that yields a tool_use block with given sections."""
+    tool_block = MagicMock()
+    tool_block.type = "tool_use"
+    tool_block.input = {"sections": sections}
+    response = MagicMock()
+    response.content = [tool_block]
+    client = MagicMock()
+    client.messages.create.return_value = response
+    return client
+
+
+def _make_llm_writer_with_mock(sections: dict[str, str], **kwargs):
+    """Instantiate LLMWriter with a mocked anthropic client."""
+    from skyknit.writer.llm_writer import LLMWriter
+
+    with _patch_anthropic():
+        writer = LLMWriter(**kwargs)
+    writer._client = _make_mock_client(sections)
+    return writer
+
+
+def _patch_anthropic():
+    """Context manager that injects a minimal anthropic stub into sys.modules."""
+    import contextlib
+
+    @contextlib.contextmanager
+    def _ctx():
+        mock_anthropic = MagicMock()
+        mock_anthropic.Anthropic.return_value = MagicMock()
+        original = sys.modules.get("anthropic")  # save before any mutation
+        sys.modules["anthropic"] = mock_anthropic
+        try:
+            yield mock_anthropic
+        finally:
+            if original is None:
+                sys.modules.pop("anthropic", None)
+            else:
+                sys.modules["anthropic"] = original
+
+    return _ctx()
+
+
+# ── TestLLMWriter ──────────────────────────────────────────────────────────────
+
+
+class TestLLMWriter:
+    def _wi(self) -> WriterInput:
+        return _drop_shoulder_writer_input()
+
+    def test_write_returns_writer_output(self):
+        wi = self._wi()
+        enhanced = {name: f"Enhanced section: {name}" for name in wi.component_order}
+        writer = _make_llm_writer_with_mock(enhanced)
+        out = writer.write(wi)
+        assert isinstance(out, WriterOutput)
+
+    def test_all_sections_present(self):
+        wi = self._wi()
+        enhanced = {name: f"Enhanced: {name}" for name in wi.component_order}
+        writer = _make_llm_writer_with_mock(enhanced)
+        out = writer.write(wi)
+        assert set(out.sections.keys()) == set(wi.component_order)
+
+    def test_component_order_preserved_in_full_pattern(self):
+        wi = self._wi()
+        # Each section has a unique marker matching its position
+        enhanced = {name: f"SECTION_{i}" for i, name in enumerate(wi.component_order)}
+        writer = _make_llm_writer_with_mock(enhanced)
+        out = writer.write(wi)
+        positions = [out.full_pattern.index(f"SECTION_{i}") for i in range(len(wi.component_order))]
+        assert positions == sorted(positions)
+
+    def test_missing_section_falls_back_to_template(self):
+        """If LLM omits a section, template prose is used for that section."""
+        from skyknit.writer.writer import TemplateWriter
+
+        wi = self._wi()
+        template_out = TemplateWriter().write(wi)
+        # LLM returns only the first section
+        first = wi.component_order[0]
+        partial = {first: "LLM-enhanced body only"}
+        writer = _make_llm_writer_with_mock(partial)
+        out = writer.write(wi)
+        # First section: LLM version
+        assert out.sections[first] == "LLM-enhanced body only"
+        # Remaining sections: template version
+        for name in wi.component_order[1:]:
+            assert out.sections[name] == template_out.sections[name]
+
+    def test_no_tool_block_falls_back_to_template(self):
+        """If Claude returns no tool_use block, return TemplateWriter output."""
+        from skyknit.writer.writer import TemplateWriter
+
+        wi = self._wi()
+        response = MagicMock()
+        response.content = []  # no tool_use block
+        client = MagicMock()
+        client.messages.create.return_value = response
+
+        with _patch_anthropic():
+            from skyknit.writer.llm_writer import LLMWriter
+
+            writer = LLMWriter()
+        writer._client = client
+
+        out = writer.write(wi)
+        template_out = TemplateWriter().write(wi)
+        assert out.full_pattern == template_out.full_pattern
+
+    def test_api_exception_falls_back_to_template(self):
+        """If the API call raises, return TemplateWriter output with a warning."""
+        from skyknit.writer.writer import TemplateWriter
+
+        wi = self._wi()
+        client = MagicMock()
+        client.messages.create.side_effect = RuntimeError("network error")
+
+        with _patch_anthropic():
+            from skyknit.writer.llm_writer import LLMWriter
+
+            writer = LLMWriter()
+        writer._client = client
+
+        with pytest.warns(UserWarning, match="LLMWriter failed"):
+            out = writer.write(wi)
+        template_out = TemplateWriter().write(wi)
+        assert out.full_pattern == template_out.full_pattern
+
+    def test_context_included_when_gauge_provided(self):
+        """Gauge context must appear in the user message when gauge is set."""
+        wi = self._wi()
+        enhanced = {name: f"Enhanced: {name}" for name in wi.component_order}
+        writer = _make_llm_writer_with_mock(enhanced, gauge=_GAUGE)
+        writer.write(wi)
+        call_kwargs = writer._client.messages.create.call_args
+        user_content = call_kwargs[1]["messages"][0]["content"]
+        assert "20.0 stitches" in user_content
+        assert "28.0 rows" in user_content
+
+    def test_no_context_when_none_passed(self):
+        """No context prefix when gauge, motif, and yarn are all None."""
+        from skyknit.writer.writer import TemplateWriter
+
+        wi = self._wi()
+        template_out = TemplateWriter().write(wi)
+        enhanced = {name: template_out.sections[name] for name in wi.component_order}
+        writer = _make_llm_writer_with_mock(enhanced)  # no gauge/motif/yarn
+        writer.write(wi)
+        call_kwargs = writer._client.messages.create.call_args
+        user_content = call_kwargs[1]["messages"][0]["content"]
+        # User message should start directly with pattern text (first section header)
+        assert user_content.startswith(wi.component_order[0].replace("_", " ").title())
+
+    def test_llm_writer_satisfies_pattern_writer_protocol(self):
+        with _patch_anthropic():
+            from skyknit.writer.llm_writer import LLMWriter
+
+            writer = LLMWriter()
+        assert isinstance(writer, PatternWriter)
+
+    def test_import_error_without_anthropic(self):
+        """LLMWriter raises ImportError if anthropic is not installed."""
+        import importlib
+        from unittest.mock import patch
+
+        import skyknit.writer.llm_writer as llm_mod
+
+        with patch.dict(sys.modules, {"anthropic": None}):  # type: ignore[dict-item]
+            importlib.reload(llm_mod)
+            with pytest.raises(ImportError, match="uv add anthropic"):
+                llm_mod.LLMWriter()
+
+        # Restore the module to its normal state after the test.
+        importlib.reload(llm_mod)
+
+
+# ── Integration tests (skipped in CI) ─────────────────────────────────────────
+
+_SKIP_LLM = pytest.mark.skipif(
+    os.environ.get("ANTHROPIC_API_KEY") is None,
+    reason="ANTHROPIC_API_KEY not set — LLM integration tests skipped",
+)
+
+
+@_SKIP_LLM
+def test_llm_writer_drop_shoulder():
+    """LLMWriter produces a non-empty pattern that parses back through check_all()."""
+    from skyknit.api.validate import validate_pattern
+    from skyknit.writer.llm_writer import LLMWriter
+
+    wi = _drop_shoulder_writer_input()
+    writer = LLMWriter(gauge=_GAUGE, stitch_motif=_MOTIF, yarn_spec=_YARN)
+    out = writer.write(wi)
+    assert out.full_pattern.strip()
+    report = validate_pattern(out.full_pattern, _GAUGE, _MOTIF, _YARN)
+    assert report.passed, f"Round-trip failed:\n{report.parse_error}\n{report.checker_result}"
+
+
+@_SKIP_LLM
+def test_llm_writer_differs_from_template():
+    """LLM output should produce richer prose than the mechanical template."""
+    from skyknit.writer.llm_writer import LLMWriter
+    from skyknit.writer.writer import TemplateWriter
+
+    wi = _drop_shoulder_writer_input()
+    template_out = TemplateWriter().write(wi)
+    llm_out = LLMWriter(gauge=_GAUGE, stitch_motif=_MOTIF, yarn_spec=_YARN).write(wi)
+    assert llm_out.full_pattern != template_out.full_pattern


### PR DESCRIPTION
Adds LLMWriter, a drop-in PatternWriter replacement that rewrites TemplateWriter prose into richer, more idiomatic knitting language using Claude's tool-use API. The two-pass design guarantees arithmetic correctness: TemplateWriter generates ground-truth numbers in pass 1; Claude enhances language only in pass 2. Falls back to TemplateWriter output with a UserWarning on any API failure.

- skyknit/writer/prompts.py: SYSTEM_PROMPT + LLM_WRITER_TOOL_SCHEMA
- skyknit/writer/llm_writer.py: LLMWriter class with _build_context helper
- skyknit/api/generate.py: add writer: PatternWriter | None = None param
- pyproject.toml: add mypy override for skyknit.writer.*
- tests/writer/test_llm_writer.py: 10 unit + 2 integration (skipped) tests
- tests/api/test_generate.py: +2 writer injection tests